### PR TITLE
fix: missing dependency relation between CI jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,7 @@ jobs:
   release:
     needs: 
       - watm_tinygo_v0_artifacts
+      - watm_tinygo_v1_artifacts
     name: "Release WATM Examples for ${{ github.ref_name }}"
     runs-on: ubuntu-latest
     steps: 


### PR DESCRIPTION
The job `release` may be executed before `watm_tinygo_v1_artifacts` finishes, which might miss unfinished artifacts and creates a racing condition.

Fix #14. 